### PR TITLE
Detect gz with Magic header bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ This demonstrates how reading a file and printing it to the command line looks l
 
 int main(int argc, char** argv) {
     auto inputFile = std::filesystem::path{argv[1]};
-    auto reader = ivio::fasta::reader{{.input = inputFile,
-                                       .compressed = false, // false by default, if true a gzip file is expected
-    }};
+    auto reader = ivio::fasta::reader{{.input = inputFile}};
     for (auto record_view : reader) {
         std::cout << "id: " << record_view.id << "\n";
         std::cout << "seq: " << record_view.seq << "\n";

--- a/docs/snippets/fasta_example_01.cpp
+++ b/docs/snippets/fasta_example_01.cpp
@@ -6,9 +6,8 @@
 
 int main(int /*argc*/, char** argv) {
     auto inputFile = std::filesystem::path{argv[1]};
-    auto reader = ivio::fasta::reader{{.input = inputFile,
-                                       .compressed = false, // false by default, if true a gzip file is expected
-    }};
+    auto reader = ivio::fasta::reader{{.input = inputFile}};
+
     for (auto record_view : reader) {
         std::cout << "id: " << record_view.id << "\n";
         std::cout << "seq: " << record_view.seq << "\n";

--- a/docs/snippets/fastq_example_01.cpp
+++ b/docs/snippets/fastq_example_01.cpp
@@ -6,9 +6,7 @@
 
 int main(int /*argc*/, char** argv) {
     auto inputFile = std::filesystem::path{argv[1]};
-    auto reader = ivio::fastq::reader{{.input = inputFile,
-                                       .compressed = false, // false by default, if true a gzip file is expected
-    }};
+    auto reader = ivio::fastq::reader{{.input = inputFile}};
     for (auto record_view : reader) {
         std::cout << "id: "   << record_view.id << "\n";
         std::cout << "seq: "  << record_view.seq << "\n";

--- a/src/ivio/detail/zlib_file_reader.h
+++ b/src/ivio/detail/zlib_file_reader.h
@@ -74,7 +74,7 @@ struct zlib_reader {
      * Function checks if the given buffer contains the magic header of a gz file.
      * See https://www.ietf.org/rfc/rfc1952.txt
      */
-    static bool checkHeader(std::span<char const> buffer) {
+    static bool isGZipHeader(std::span<char const> buffer) {
         auto view = std::string_view{buffer.data(), buffer.size()};
         return view.starts_with("\x1f\x8b");
     }

--- a/src/ivio/detail/zlib_file_reader.h
+++ b/src/ivio/detail/zlib_file_reader.h
@@ -69,6 +69,15 @@ struct zlib_reader {
             }
         }
     }
+
+    /**
+     * Function checks if the given buffer contains the magic header of a gz file
+     */
+    static bool checkHeader(std::span<char const> buffer) {
+        return buffer.size() >= 2
+            && buffer[0] == (char)0x1f
+            && buffer[1] == (char)0x8b;
+    }
 };
 
 static_assert(Readable<zlib_reader>);

--- a/src/ivio/detail/zlib_file_reader.h
+++ b/src/ivio/detail/zlib_file_reader.h
@@ -75,9 +75,8 @@ struct zlib_reader {
      * See https://www.ietf.org/rfc/rfc1952.txt
      */
     static bool checkHeader(std::span<char const> buffer) {
-        return buffer.size() >= 2
-            && buffer[0] == (char)0x1f
-            && buffer[1] == (char)0x8b;
+        auto view = std::string_view{buffer.data(), buffer.size()};
+        return view.starts_with("\x1f\x8b");
     }
 };
 

--- a/src/ivio/detail/zlib_file_reader.h
+++ b/src/ivio/detail/zlib_file_reader.h
@@ -71,7 +71,8 @@ struct zlib_reader {
     }
 
     /**
-     * Function checks if the given buffer contains the magic header of a gz file
+     * Function checks if the given buffer contains the magic header of a gz file.
+     * See https://www.ietf.org/rfc/rfc1952.txt
      */
     static bool checkHeader(std::span<char const> buffer) {
         return buffer.size() >= 2

--- a/src/ivio/fasta/reader.cpp
+++ b/src/ivio/fasta/reader.cpp
@@ -26,10 +26,7 @@ struct reader_base<fasta::reader>::pimpl {
         : ureader {[&]() -> VarBufferedReader {
             auto reader = mmap_reader{file}; // create a reader and peak into the file
             auto [buffer, len] = reader.read(2);
-
-            if (len >= 2
-                && buffer[0] == (char)0x1f
-                && buffer[1] == (char)0x8b) {
+            if (zlib_reader::checkHeader({buffer, len})) {
                 return zlib_reader{std::move(reader)};
             }
             return reader;
@@ -41,9 +38,7 @@ struct reader_base<fasta::reader>::pimpl {
             auto buffer = std::array<char, 2>{};
             auto len = reader.read(buffer);
             reader.seek(0);
-            if (len >= 2
-                && buffer[0] == (char)0x1f
-                && buffer[1] == (char)0x8b) {
+            if (zlib_reader::checkHeader({buffer.data(), len})) {
                 return zlib_reader{std::move(reader)};
             }
             return reader;

--- a/src/ivio/fasta/reader.cpp
+++ b/src/ivio/fasta/reader.cpp
@@ -26,7 +26,7 @@ struct reader_base<fasta::reader>::pimpl {
         : ureader {[&]() -> VarBufferedReader {
             auto reader = mmap_reader{file}; // create a reader and peak into the file
             auto [buffer, len] = reader.read(2);
-            if (zlib_reader::checkHeader({buffer, len})) {
+            if (zlib_reader::isGZipHeader({buffer, len})) {
                 return zlib_reader{std::move(reader)};
             }
             return reader;
@@ -38,7 +38,7 @@ struct reader_base<fasta::reader>::pimpl {
             auto buffer = std::array<char, 2>{};
             auto len = reader.read(buffer);
             reader.seek(0);
-            if (zlib_reader::checkHeader({buffer.data(), len})) {
+            if (zlib_reader::isGZipHeader({buffer.data(), len})) {
                 return zlib_reader{std::move(reader)};
             }
             return reader;

--- a/src/ivio/fasta/reader.h
+++ b/src/ivio/fasta/reader.h
@@ -21,9 +21,6 @@ struct reader : public reader_base<reader> {
     struct config {
         // Source: file or stream
         std::variant<std::filesystem::path, std::reference_wrapper<std::istream>> input;
-
-        // This is only relevant if a stream is being used
-        bool compressed{};
     };
 
 public:

--- a/src/ivio/fastq/reader.cpp
+++ b/src/ivio/fastq/reader.cpp
@@ -17,21 +17,18 @@ struct reader_base<fastq::reader>::pimpl {
 
     pimpl(std::filesystem::path file, bool)
         : ureader {[&]() -> VarBufferedReader {
-            if (file.extension() == ".fq") {
-                return mmap_reader{file};
-            } else if (file.extension() == ".gz") {
+            if (file.extension() == ".gz") {
                 return zlib_reader{mmap_reader{file}};
             }
-            throw std::runtime_error("unknown file extension");
+            return mmap_reader{file};
         }()}
     {}
     pimpl(std::istream& file, bool compressed)
         : ureader {[&]() -> VarBufferedReader {
             if (!compressed) {
                 return stream_reader{file};
-            } else {
-                return zlib_reader{stream_reader{file}};
             }
+            return zlib_reader{stream_reader{file}};
         }()}
     {}
 };

--- a/src/ivio/fastq/reader.cpp
+++ b/src/ivio/fastq/reader.cpp
@@ -19,7 +19,7 @@ struct reader_base<fastq::reader>::pimpl {
         : ureader {[&]() -> VarBufferedReader {
             auto reader = mmap_reader{file}; // create a reader and peak into the file
             auto [buffer, len] = reader.read(2);
-            if (zlib_reader::checkHeader({buffer, len})) {
+            if (zlib_reader::isGZipHeader({buffer, len})) {
                 return zlib_reader{std::move(reader)};
             }
             return reader;
@@ -31,7 +31,7 @@ struct reader_base<fastq::reader>::pimpl {
             auto buffer = std::array<char, 2>{};
             auto len = reader.read(buffer);
             reader.seek(0);
-            if (zlib_reader::checkHeader({buffer.data(), len})) {
+            if (zlib_reader::isGZipHeader({buffer.data(), len})) {
                 return zlib_reader{std::move(reader)};
             }
             return reader;

--- a/src/ivio/fastq/reader.h
+++ b/src/ivio/fastq/reader.h
@@ -20,9 +20,6 @@ struct reader : public reader_base<reader> {
     struct config {
         // Source: file or stream
         std::variant<std::filesystem::path, std::reference_wrapper<std::istream>> input;
-
-        // This is only relevant if a stream is being used
-        bool compressed{};
     };
 
 public:

--- a/src/test_ivio/fasta_reader.cpp
+++ b/src/test_ivio/fasta_reader.cpp
@@ -439,7 +439,7 @@ TEST_CASE("reading compressed fasta files", "[fasta][reader][gz][short]") {
 
     SECTION("Read from std::ifstream") {
         auto fs = std::ifstream{tmp / "file.fa.gz"};
-        auto reader = ivio::fasta::reader{{.input = fs, .compressed = true}};
+        auto reader = ivio::fasta::reader{{.input = fs}};
         auto vec = std::vector(begin(reader), end(reader));
         static_assert(std::same_as<decltype(vec), decltype(expected)>, "vec and expected should have the exact same type");
         CHECK(expected == vec);


### PR DESCRIPTION
This removes the file extension attribute and determines the type of the file based magic header bytes of gzip files.